### PR TITLE
D.not 수정 및 D.eq, D.seq 제안

### DIFF
--- a/example/js/abc.js
+++ b/example/js/abc.js
@@ -309,24 +309,52 @@
     C.div = F("TODO");
 
     function D() {}
-    D.to_array = function(obj) { return _.toArray(arguments.length > 1 ? arguments : obj); };
 
-    D.not = function(arr) {
-      var args = _.toArray(arguments.length > 1 ? arguments : arr);
-      return C.find(args, function(val) { return Boolean(val) === false; }) === void 0 ? false : true;
-    };
+    D.to_array = _.toArray;
+    D.not = _.negate(I);
+    // D.t = D.true = J(true);
+    // D.f = D.false = J(false);
+    // G['=== 0']= G['===0'] = D.is_zero = function(v) { return v === 0; };
+    // G['=== -1']= G['===-1'] = function(v) { return v === -1; };
+
+    D.and = function(v) { return !!(v && _.findIndex(arguments, function(v) { return !v; }) === -1); };
+    // D.and = IF([P, B.find_i(D.not), '===-1']).ELSE(D.f);
+    // D.and = IF([P, B(X, D.not, _.findIndex), BD.eq(-1)]).ELSE(J(false));
+
+    D.or = B([P, B.find(I), _.negate(function(v) { return v === void 0; })]);
 
     D.eq = function(arr) {
-      var args = _.toArray(arguments.length > 1 ? arguments : arr), flag = false;
-      C.find(args, function(val) { flag = args[0] == val ? true : false; return !flag; });
-      return flag;
+      var args = _.isArray(arr) ? arr : D.to_array(arguments);
+      return (C.find(args, function(val) { return args[0] != val; })) === void 0;
     };
 
     D.seq = function(arr) {
-      var args = _.toArray(arguments.length > 1 ? arguments : arr), flag = false;
-      C.find(args, function(val) { flag = args[0] === val ? true : false; return !flag; });
+      var args =  _.isArray(arr) ? arr : D.to_array(arguments), flag = false;
+      C.find(args, function(val) { flag = args[0] === val; return !flag; });
       return flag;
-    };    
+    };
+
+    D.neq = _.negate(D.eq);
+    D.sneq = _.negate(D.seq);
+
+    D.add = function(arr) {
+      var args = _.isArray(arr) ? arr : _.toArray(arguments);
+      return args.reduce(function(a,b) { return a + b; });
+    };
+
+    D.sub = function(arr) {
+      var args = _.isArray(arr) ? arr : _.toArray(arguments);
+      return args.reduce(function(a,b) { return a - b; });
+    };
+
+    D.parseInt = function(arr) {
+      var args = _.isArray(arr) ? arr : _.toArray(arguments);
+      return C.map(args, function(v) { return parseInt(v); });
+    };
+
+    D.iadd = B([D.parseInt, D.add]);
+    D.isub = B([D.parseInt, D.sub]);
+
 
     function F(nodes) {
         var f = V(G, nodes);
@@ -747,6 +775,12 @@ function respect_underscore() {
     _.uniqueId = function(prefix) {
         var id = ++idCounter + '';
         return prefix ? prefix + id : id;
+    };
+
+    _.negate = function(predicate) {
+        return function() {
+            return !predicate.apply(this, arguments);
+        };
     };
 
     return _;

--- a/example/js/abc.js
+++ b/example/js/abc.js
@@ -311,6 +311,10 @@
     function D() {}
     D.to_array = function(obj) { return _.toArray(arguments.length > 1 ? arguments : obj); };
 
+    D.not = function() {
+      return D.to_array(arguments).find(function(val) { return Boolean(val) === false; }) === void 0 ? false : true;
+    };
+
     function F(nodes) {
         var f = V(G, nodes);
         var err = Error('warning: ' + nodes + ' is not defined').stack;

--- a/example/js/abc.js
+++ b/example/js/abc.js
@@ -311,9 +311,22 @@
     function D() {}
     D.to_array = function(obj) { return _.toArray(arguments.length > 1 ? arguments : obj); };
 
-    D.not = function() {
-      return D.to_array(arguments).find(function(val) { return Boolean(val) === false; }) === void 0 ? false : true;
+    D.not = function(arr) {
+      var args = _.toArray(arguments.length > 1 ? arguments : arr);
+      return C.find(args, function(val) { return Boolean(val) === false; }) === void 0 ? false : true;
     };
+
+    D.eq = function(arr) {
+      var args = _.toArray(arguments.length > 1 ? arguments : arr), flag = false;
+      C.find(args, function(val) { flag = args[0] == val ? true : false; return !flag; });
+      return flag;
+    };
+
+    D.seq = function(arr) {
+      var args = _.toArray(arguments.length > 1 ? arguments : arr), flag = false;
+      C.find(args, function(val) { flag = args[0] === val ? true : false; return !flag; });
+      return flag;
+    };    
 
     function F(nodes) {
         var f = V(G, nodes);


### PR DESCRIPTION
# 주요 내용
### 01. D.not의 수정 사항을 반영했습니다. #1
- **원인**: 매개변수로 받은 값을 배열로 변환하는 `D.to_array`를 사용했는데, 무엇이 문제인지 같은 로직임에도 배열이 다중 배열로 반환됩니다.
- **해결**: `var args = _.toArray(arguments.length > 1 ? arguments : arr);` 이와 같이 `D.to_array` 함수의 코드를 참고하여 arguments를 배열로 전환했습니다. 
### 02. D.eq, D.seq 함수를 구현했습니다.
- 복수의 인자값, 배열, `null`, `undefined`를 매개변수로 전달하여 테스트 했습니다.
