### PR TITLE
D series 제출

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/example/D_test.html

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-/example/D_test.html
+/example/TDD.html
 .idea/

--- a/example/js/abc.js
+++ b/example/js/abc.js
@@ -309,24 +309,52 @@
     C.div = F("TODO");
 
     function D() {}
-    D.to_array = function(obj) { return _.toArray(arguments.length > 1 ? arguments : obj); };
 
-    D.not = function(arr) {
-      var args = _.toArray(arguments.length > 1 ? arguments : arr);
-      return C.find(args, function(val) { return Boolean(val) === false; }) === void 0 ? false : true;
-    };
+    D.to_array = _.toArray;
+    D.not = _.negate(I);
+    // D.t = D.true = J(true);
+    // D.f = D.false = J(false);
+    // G['=== 0']= G['===0'] = D.is_zero = function(v) { return v === 0; };
+    // G['=== -1']= G['===-1'] = function(v) { return v === -1; };
+
+    D.and = function(v) { return !!(v && _.findIndex(arguments, function(v) { return !v; }) === -1); };
+    // D.and = IF([P, B.find_i(D.not), '===-1']).ELSE(D.f);
+    // D.and = IF([P, B(X, D.not, _.findIndex), BD.eq(-1)]).ELSE(J(false));
+
+    D.or = B([P, B.find(I), _.negate(function(v) { return v === void 0; })]);
 
     D.eq = function(arr) {
-      var args = _.toArray(arguments.length > 1 ? arguments : arr), flag = false;
-      C.find(args, function(val) { flag = args[0] == val ? true : false; return !flag; });
-      return flag;
+      var args = _.isArray(arr) ? arr : D.to_array(arguments);
+      return (C.find(args, function(val) { return args[0] != val; })) === void 0;
     };
 
     D.seq = function(arr) {
-      var args = _.toArray(arguments.length > 1 ? arguments : arr), flag = false;
-      C.find(args, function(val) { flag = args[0] === val ? true : false; return !flag; });
+      var args =  _.isArray(arr) ? arr : D.to_array(arguments), flag = false;
+      C.find(args, function(val) { flag = args[0] === val; return !flag; });
       return flag;
-    };    
+    };
+
+    D.neq = _.negate(D.eq);
+    D.sneq = _.negate(D.seq);
+
+    D.add = function(arr) {
+      var args = _.isArray(arr) ? arr : _.toArray(arguments);
+      return args.reduce(function(a,b) { return a + b; });
+    };
+
+    D.sub = function(arr) {
+      var args = _.isArray(arr) ? arr : _.toArray(arguments);
+      return args.reduce(function(a,b) { return a - b; });
+    };
+
+    D.parseInt = function(arr) {
+      var args = _.isArray(arr) ? arr : _.toArray(arguments);
+      return C.map(args, function(v) { return parseInt(v); });
+    };
+
+    D.iadd = B([D.parseInt, D.add]);
+    D.isub = B([D.parseInt, D.sub]);
+
 
     function F(nodes) {
         var f = V(G, nodes);
@@ -747,6 +775,12 @@ function respect_underscore() {
     _.uniqueId = function(prefix) {
         var id = ++idCounter + '';
         return prefix ? prefix + id : id;
+    };
+
+    _.negate = function(predicate) {
+        return function() {
+            return !predicate.apply(this, arguments);
+        };
     };
 
     return _;

--- a/example/js/abc.js
+++ b/example/js/abc.js
@@ -311,6 +311,10 @@
     function D() {}
     D.to_array = function(obj) { return _.toArray(arguments.length > 1 ? arguments : obj); };
 
+    D.not = function() {
+      return D.to_array(arguments).find(function(val) { return Boolean(val) === false; }) === void 0 ? false : true;
+    };
+
     function F(nodes) {
         var f = V(G, nodes);
         var err = Error('warning: ' + nodes + ' is not defined').stack;

--- a/example/js/abc.js
+++ b/example/js/abc.js
@@ -310,22 +310,29 @@
 
     function D() {}
 
-    D.to_array = _.toArray;
-    D.not = _.negate(I);
-    // D.t = D.true = J(true);
-    // D.f = D.false = J(false);
     // G['=== 0']= G['===0'] = D.is_zero = function(v) { return v === 0; };
     // G['=== -1']= G['===-1'] = function(v) { return v === -1; };
 
+    D.t = D.true = J(true);
+    D.f = D.false = J(false);
+    D.to_array = _.toArray;
+
+    D.not = function(v) { return !v; };
     D.and = function(v) { return !!(v && _.findIndex(arguments, function(v) { return !v; }) === -1); };
     // D.and = IF([P, B.find_i(D.not), '===-1']).ELSE(D.f);
     // D.and = IF([P, B(X, D.not, _.findIndex), BD.eq(-1)]).ELSE(J(false));
+    D.or = B([P, B.find(I), function(v) { return v !== void 0; }]);
 
-    D.or = B([P, B.find(I), _.negate(function(v) { return v === void 0; })]);
+    D.add = B([D.arr_or_p_to_array = IF(_.isArray, I).ELSE([P, D.to_array]), B.reduce(function(a, b) { return a + b; })]);
+    D.sub = B([D.arr_or_p_to_array, B.reduce(function(a, b) { return a - b; })]);
+
+    D.parse_int = B([D.arr_or_p_to_array, B.map(function(v) { return parseInt(v); })]);
+    D.iadd = B([D.parse_int, D.add]);
+    D.isub = B([D.parse_int, D.sub]);
 
     D.eq = function(arr) {
       var args = _.isArray(arr) ? arr : D.to_array(arguments);
-      return (C.find(args, function(val) { return args[0] != val; })) === void 0;
+      return (_.findIndex(args, function(v) { return args[0] != v; })) === -1;
     };
 
     D.seq = function(arr) {
@@ -334,26 +341,8 @@
       return flag;
     };
 
-    D.neq = _.negate(D.eq);
-    D.sneq = _.negate(D.seq);
-
-    D.add = function(arr) {
-      var args = _.isArray(arr) ? arr : _.toArray(arguments);
-      return args.reduce(function(a,b) { return a + b; });
-    };
-
-    D.sub = function(arr) {
-      var args = _.isArray(arr) ? arr : _.toArray(arguments);
-      return args.reduce(function(a,b) { return a - b; });
-    };
-
-    D.parseInt = function(arr) {
-      var args = _.isArray(arr) ? arr : _.toArray(arguments);
-      return C.map(args, function(v) { return parseInt(v); });
-    };
-
-    D.iadd = B([D.parseInt, D.add]);
-    D.isub = B([D.parseInt, D.sub]);
+    D.neq = function() { return !A(arguments, D.eq); };
+    D.sneq = function() { return !A(arguments, D.seq); };
 
 
     function F(nodes) {
@@ -775,12 +764,6 @@ function respect_underscore() {
     _.uniqueId = function(prefix) {
         var id = ++idCounter + '';
         return prefix ? prefix + id : id;
-    };
-
-    _.negate = function(predicate) {
-        return function() {
-            return !predicate.apply(this, arguments);
-        };
     };
 
     return _;

--- a/example/js/abc.js
+++ b/example/js/abc.js
@@ -25,6 +25,7 @@
     F.U = window.U = U; // _.noop, return undefined
     F.V = window.V = V; // get value with string
     F.X = window.X = new Object();
+    F.BD = window.BD = BD;
 
     function has_Promise() { return has_Promise.__cache || (has_Promise.__cache = !!V(window, 'Promise.prototype.then')); }
 
@@ -339,18 +340,21 @@
     D.f = D.false = J(false);
     D.to_array = _.toArray;
 
-    // BD를 전역으로 만들어주면 D.is를 지울 것! => 당연히 아래에 사용된 D.is 는 BD.is로 바꿔줄 것!
-    BD.is = D.is = function(b) { return B([D.arr_or_p_to_array, B.find(function(v){ return b != v; }), function(v) { return v === void 0; }]); };
-    BD.isnt = D.isnt = function(b) { return B([D.arr_or_p_to_array, B.find(function(v) { return b == v; }), D.is(void 0)]); };
+    BD.is = function(a) {
+      return function(arr) {
+        return _.findIndex(_.isArray(arr) ? arr : _.toArray(arguments), function(v) { return a !== v; }) === -1;
+      };
+    };
+    BD.isnt = function(a) {
+      return function(arr) {
+        return _.findIndex(_.isArray(arr) ? arr : _.toArray(arguments), function(v) { return a === v; }) === -1;
+      };
+    };
 
     D.not = function(v) { return !v; };
-    D.notnot = function(v) { return !!v; };
-
+    D.nnot = function(v) { return !!v; };
     D.and = function(v) { return !!(v && _.findIndex(arguments, function(v) { return !v; }) === -1); };
-    // D.and = IF([P, B.find_i(D.not), '===-1']).ELSE(D.f);
-    // D.and = IF([P, B(X, D.not, _.findIndex), BD.eq(-1)]).ELSE(J(false));
-
-    D.or = B([P, B.find(I), D.notnot]);
+    D.or = B([P, B.find(I), D.nnot]);
 
     D.add = B([D.arr_or_p_to_array = IF(_.isArray, I).ELSE([P, D.to_array]), B.reduce(function(a, b) { return a + b; })]);
     D.sub = B([D.arr_or_p_to_array, B.reduce(function(a, b) { return a - b; })]);
@@ -362,14 +366,8 @@
     D.iadd = B([D.parse_int, D.add]);
     D.isub = B([D.parse_int, D.sub]);
 
-    D.eq = B([D.arr_or_p_to_array, B.find(function(v,i,a) { return a[0] != v; }), D.is(void 0)]);
-    // D.eq = B([D.arr_or_p_to_array, B.find_i(function(v,i,a) { return a[0] != v; }), BD.is(-1)]); // find_i가 구현되면 사용할 함수 => 위 함수는 제거
-
-    D.seq = function(arr) {
-      var args =  _.isArray(arr) ? arr : D.to_array(arguments);
-      return D.is(-1)(_.findIndex(args, function(v) { return args[0] !== v; }));
-    };
-    // D.seq = B([D.arr_or_p_to_array, B.find_i(function(v,i,a) { return a[0] !== v; }), BD.is(-1)]); // find_i가 구현되면 사용할 함수 => 위 함수는 제거
+    D.eq = B([D.arr_or_p_to_array, B(X, function(v,i,a) { return a[0] != v; }, _.findIndex), BD.is(-1)]);
+    D.seq = B([D.arr_or_p_to_array, B(X, function(v,i,a) { return a[0] !== v; }, _.findIndex), BD.is(-1)]);
 
     D.neq = B([D.eq, D.not]);
     D.sneq = B([D.seq, D.not]);

--- a/example/js/abc.js
+++ b/example/js/abc.js
@@ -311,9 +311,22 @@
     function D() {}
     D.to_array = function(obj) { return _.toArray(arguments.length > 1 ? arguments : obj); };
 
-    D.not = function() {
-      return D.to_array(arguments).find(function(val) { return Boolean(val) === false; }) === void 0 ? false : true;
+    D.not = function(arr) {
+      var args = _.toArray(arguments.length > 1 ? arguments : arr);
+      return C.find(args, function(val) { return Boolean(val) === false; }) === void 0 ? false : true;
     };
+
+    D.eq = function(arr) {
+      var args = _.toArray(arguments.length > 1 ? arguments : arr), flag = false;
+      C.find(args, function(val) { flag = args[0] == val ? true : false; return !flag; });
+      return flag;
+    };
+
+    D.seq = function(arr) {
+      var args = _.toArray(arguments.length > 1 ? arguments : arr), flag = false;
+      C.find(args, function(val) { flag = args[0] === val ? true : false; return !flag; });
+      return flag;
+    };    
 
     function F(nodes) {
         var f = V(G, nodes);

--- a/example/js/abc.js
+++ b/example/js/abc.js
@@ -340,19 +340,24 @@
 
     /* D start */
     function D() {}
-    function BD() {} // BD를 전역으로 만들어줘야 함
+    function BD() {}
     // G['=== 0']= G['===0'] = D.is_zero = function(v) { return v === 0; };
     // G['=== -1']= G['===-1'] = function(v) { return v === -1; };
 
+    D.log = function(v) { console.log(v); return v; };
     D.t = D.true = J(true);
     D.f = D.false = J(false);
     D.to_array = _.toArray;
 
+    // BD.is = function(a) { return B([D.arr_or_p_to_array, B(X, function(v) { return a !== v; }, _.findIndex), function(v) { return v === -1; }]); };
+    // BD.isnt = function(a) { return B([D.arr_or_p_to_array, B(X, function(v) { return a === v; }, _.findIndex), BD.is(-1)]); };
+
     BD.is = function(a) {
-      return function(arr) {
-        return _.findIndex(_.isArray(arr) ? arr : _.toArray(arguments), function(v) { return a !== v; }) === -1;
+       return function(arr) {
+         return _.findIndex(_.isArray(arr) ? arr : _.toArray(arguments), function(v) { return a !== v; }) === -1;
       };
     };
+
     BD.isnt = function(a) {
       return function(arr) {
         return _.findIndex(_.isArray(arr) ? arr : _.toArray(arguments), function(v) { return a === v; }) === -1;
@@ -361,7 +366,9 @@
 
     D.not = function(v) { return !v; };
     D.nnot = function(v) { return !!v; };
-    D.and = function(v) { return !!(v && _.findIndex(arguments, function(v) { return !v; }) === -1); };
+
+    // D.and = IF([P, B(X, D.not, _.findIndex), function(v) { return v === -1; }]).ELSE(D.f);
+    D.and = IF([P, B(X, D.not, _.findIndex), BD.is(-1)]).ELSE(D.f);
     D.or = B([P, B.find(I), D.nnot]);
 
     D.add = B([D.arr_or_p_to_array = IF(_.isArray, I).ELSE([P, D.to_array]), B.reduce(function(a, b) { return a + b; })]);

--- a/example/js/abc.js
+++ b/example/js/abc.js
@@ -357,34 +357,21 @@
     // G['=== 0']= G['===0'] = D.is_zero = function(v) { return v === 0; };
     // G['=== -1']= G['===-1'] = function(v) { return v === -1; };
 
-    D.log = function(v) { console.log(v); return v; };
     D.t = D.true = J(true);
     D.f = D.false = J(false);
     D.to_array = _.toArray;
+    D.arr_or_p_to_array = IF(_.isArray, I).ELSE([P, D.to_array]);
 
-    // BD.is = function(a) { return B([D.arr_or_p_to_array, B(X, function(v) { return a !== v; }, _.findIndex), function(v) { return v === -1; }]); };
-    // BD.isnt = function(a) { return B([D.arr_or_p_to_array, B(X, function(v) { return a === v; }, _.findIndex), BD.is(-1)]); };
-
-    BD.is = function(a) {
-       return function(arr) {
-         return _.findIndex(_.isArray(arr) ? arr : _.toArray(arguments), function(v) { return a !== v; }) === -1;
-      };
-    };
-
-    BD.isnt = function(a) {
-      return function(arr) {
-        return _.findIndex(_.isArray(arr) ? arr : _.toArray(arguments), function(v) { return a === v; }) === -1;
-      };
-    };
+    BD.is = function(a) { return B([D.arr_or_p_to_array, B.find_i(function(v) { return a !== v; }), function(v) { return v === -1; }]); };
+    BD.isnt = function(a) { return B([D.arr_or_p_to_array, B.find_i(function(v) { return a === v; }), BD.is(-1)]); };
 
     D.not = function(v) { return !v; };
     D.nnot = function(v) { return !!v; };
 
-    // D.and = IF([P, B(X, D.not, _.findIndex), function(v) { return v === -1; }]).ELSE(D.f);
-    D.and = IF([P, B(X, D.not, _.findIndex), BD.is(-1)]).ELSE(D.f);
-    D.or = B([P, B.find(I), D.nnot]);
+    D.and = B([D.arr_or_p_to_array, B.find_i(D.not), BD.is(-1)]);
+    D.or = B([D.arr_or_p_to_array, B.find(I), D.nnot]);
 
-    D.add = B([D.arr_or_p_to_array = IF(_.isArray, I).ELSE([P, D.to_array]), B.reduce(function(a, b) { return a + b; })]);
+    D.add = B([D.arr_or_p_to_array, B.reduce(function(a, b) { return a + b; })]);
     D.sub = B([D.arr_or_p_to_array, B.reduce(function(a, b) { return a - b; })]);
     D.mod = B([D.arr_or_p_to_array, B.reduce(function(a, b) { return a % b; })]);
     D.mul = B([D.arr_or_p_to_array, B.reduce(function(a, b) { return a * b; })]);
@@ -394,8 +381,8 @@
     D.iadd = B([D.parse_int, D.add]);
     D.isub = B([D.parse_int, D.sub]);
 
-    D.eq = B([D.arr_or_p_to_array, B(X, function(v,i,a) { return a[0] != v; }, _.findIndex), BD.is(-1)]);
-    D.seq = B([D.arr_or_p_to_array, B(X, function(v,i,a) { return a[0] !== v; }, _.findIndex), BD.is(-1)]);
+    D.eq = B([D.arr_or_p_to_array, B.find_i(function(v,i,a) { return a[0] != v; }), BD.is(-1)]);
+    D.seq = B([D.arr_or_p_to_array, B.find_i(function(v,i,a) { return a[0] !== v; }), BD.is(-1)]);
 
     D.neq = B([D.eq, D.not]);
     D.sneq = B([D.seq, D.not]);
@@ -667,7 +654,7 @@ function respect_underscore(_) {
     _.property = function(key) { return function(obj) { return obj == null ? void 0 : obj[key]; }; };
 
     var MAX_ARRAY_INDEX = Math.pow(2, 53) - 1;
-    var getLength = function(obj) { return obj.length };
+    var getLength = function(obj) { return obj.length; };
     var isArrayLike = function(collection) {
         var length = getLength(collection);
         return typeof length == 'number' && length >= 0 && length <= MAX_ARRAY_INDEX;

--- a/example/js/abc.js
+++ b/example/js/abc.js
@@ -360,18 +360,8 @@
     D.t = D.true = J(true);
     D.f = D.false = J(false);
     D.to_array = _.toArray;
-    D.arr_or_p_to_array = IF(_.isArray, I).ELSE([P, D.to_array]);
-
-    BD.is = function(a) { return B([D.arr_or_p_to_array, B.find_i(function(v) { return a !== v; }), function(v) { return v === -1; }]); };
-    BD.isnt = function(a) { return B([D.arr_or_p_to_array, B.find_i(function(v) { return a === v; }), BD.is(-1)]); };
-
-    D.not = function(v) { return !v; };
-    D.nnot = function(v) { return !!v; };
-
-    D.and = B([D.arr_or_p_to_array, B.find_i(D.not), BD.is(-1)]);
-    D.or = B([D.arr_or_p_to_array, B.find(I), D.nnot]);
-
-    D.add = B([D.arr_or_p_to_array, B.reduce(function(a, b) { return a + b; })]);
+    
+    D.add = B([D.arr_or_p_to_array = IF(_.isArray, I).ELSE([P, D.to_array]), B.reduce(function(a, b) { return a + b; })]);
     D.sub = B([D.arr_or_p_to_array, B.reduce(function(a, b) { return a - b; })]);
     D.mod = B([D.arr_or_p_to_array, B.reduce(function(a, b) { return a % b; })]);
     D.mul = B([D.arr_or_p_to_array, B.reduce(function(a, b) { return a * b; })]);
@@ -380,6 +370,15 @@
     D.parse_int = B([D.arr_or_p_to_array, B.map(function(v) { return parseInt(v); })]);
     D.iadd = B([D.parse_int, D.add]);
     D.isub = B([D.parse_int, D.sub]);
+
+    BD.is = function(a) { return B([D.arr_or_p_to_array, B.find_i(function(v) { return a !== v; }), function(v) { return v === -1; }]); };
+    BD.isnt = function(a) { return B([D.arr_or_p_to_array, B.find_i([I, BD.is(a)]), BD.is(-1)]); };
+
+    D.not = function(v) { return !v; };
+    D.nnot = function(v) { return !!v; };
+
+    D.and = B([D.arr_or_p_to_array, B.find_i(D.not), BD.is(-1)]);
+    D.or = B([D.arr_or_p_to_array, B.find(I), D.nnot]);
 
     D.eq = B([D.arr_or_p_to_array, B.find_i(function(v,i,a) { return a[0] != v; }), BD.is(-1)]);
     D.seq = B([D.arr_or_p_to_array, B.find_i(function(v,i,a) { return a[0] !== v; }), BD.is(-1)]);

--- a/example/js/abc.js
+++ b/example/js/abc.js
@@ -329,8 +329,9 @@
     C.all = F("TODO");
     C.div = F("TODO");
 
+    /* D start */
     function D() {}
-
+    function BD() {} // BD를 전역으로 만들어줘야 함
     // G['=== 0']= G['===0'] = D.is_zero = function(v) { return v === 0; };
     // G['=== -1']= G['===-1'] = function(v) { return v === -1; };
 
@@ -338,32 +339,40 @@
     D.f = D.false = J(false);
     D.to_array = _.toArray;
 
+    // BD를 전역으로 만들어주면 D.is를 지울 것! => 당연히 아래에 사용된 D.is 는 BD.is로 바꿔줄 것!
+    BD.is = D.is = function(b) { return B([D.arr_or_p_to_array, B.find(function(v){ return b != v; }), function(v) { return v === void 0; }]); };
+    BD.isnt = D.isnt = function(b) { return B([D.arr_or_p_to_array, B.find(function(v) { return b == v; }), D.is(void 0)]); };
+
     D.not = function(v) { return !v; };
+    D.notnot = function(v) { return !!v; };
+
     D.and = function(v) { return !!(v && _.findIndex(arguments, function(v) { return !v; }) === -1); };
     // D.and = IF([P, B.find_i(D.not), '===-1']).ELSE(D.f);
     // D.and = IF([P, B(X, D.not, _.findIndex), BD.eq(-1)]).ELSE(J(false));
-    D.or = B([P, B.find(I), function(v) { return v !== void 0; }]);
+
+    D.or = B([P, B.find(I), D.notnot]);
 
     D.add = B([D.arr_or_p_to_array = IF(_.isArray, I).ELSE([P, D.to_array]), B.reduce(function(a, b) { return a + b; })]);
     D.sub = B([D.arr_or_p_to_array, B.reduce(function(a, b) { return a - b; })]);
+    D.mod = B([D.arr_or_p_to_array, B.reduce(function(a, b) { return a % b; })]);
+    D.mul = B([D.arr_or_p_to_array, B.reduce(function(a, b) { return a * b; })]);
+    D.div = B([D.arr_or_p_to_array, B.reduce(function(a, b) { return a / b; })]);
 
     D.parse_int = B([D.arr_or_p_to_array, B.map(function(v) { return parseInt(v); })]);
     D.iadd = B([D.parse_int, D.add]);
     D.isub = B([D.parse_int, D.sub]);
 
-    D.eq = function(arr) {
-      var args = _.isArray(arr) ? arr : D.to_array(arguments);
-      return (_.findIndex(args, function(v) { return args[0] != v; })) === -1;
-    };
+    D.eq = B([D.arr_or_p_to_array, B.find(function(v,i,a) { return a[0] != v; }), D.is(void 0)]);
+    // D.eq = B([D.arr_or_p_to_array, B.find_i(function(v,i,a) { return a[0] != v; }), BD.is(-1)]); // find_i가 구현되면 사용할 함수 => 위 함수는 제거
 
     D.seq = function(arr) {
-      var args =  _.isArray(arr) ? arr : D.to_array(arguments), flag = false;
-      C.find(args, function(val) { flag = args[0] === val; return !flag; });
-      return flag;
+      var args =  _.isArray(arr) ? arr : D.to_array(arguments);
+      return D.is(-1)(_.findIndex(args, function(v) { return args[0] !== v; }));
     };
+    // D.seq = B([D.arr_or_p_to_array, B.find_i(function(v,i,a) { return a[0] !== v; }), BD.is(-1)]); // find_i가 구현되면 사용할 함수 => 위 함수는 제거
 
-    D.neq = function() { return !A(arguments, D.eq); };
-    D.sneq = function() { return !A(arguments, D.seq); };
+    D.neq = B([D.eq, D.not]);
+    D.sneq = B([D.seq, D.not]);
 
 
     function F(nodes) {
@@ -609,6 +618,7 @@ function respect_underscore(_) {
         if (_.isObject(value)) return _.matcher(value);
         return B.V(value);
     };
+
 
     var createAssigner = function(keysFunc, undefinedOnly) {
         return function(obj) {

--- a/example/js/abc.js
+++ b/example/js/abc.js
@@ -11,7 +11,6 @@
     F.B = window.B = B; // thisless bind, like underscore partial
     F.B2 = window.B2 = B2; // 우리만씀
     F.C = window.C = C; // thisless call
-    F.D = window.D = D; // Data
     F.E = window.E = _.extend;
     F.F = window.F = F; // find function
     F.H = window.H = H; // HTML Template Engine
@@ -27,7 +26,6 @@
     F.U = window.U = U; // _.noop, return undefined
     F.V = window.V = V; // get value with string
     F.X = window.X = new Object();
-    F.BD = window.BD = BD;
 
     function has_Promise() { return has_Promise.__cache || (has_Promise.__cache = !!V(window, 'Promise.prototype.then')); }
 
@@ -53,6 +51,7 @@
     }
     function B() { return base_b(arguments); }
     function B2() { return base_b(arguments, true); }
+    function B3() { return B(C.to_array(arguments)); }
 
     function base_bp(next, idx) {
         if (arguments.length == 2) return function () { return arguments[idx] };
@@ -238,6 +237,8 @@
         });
     };
 
+    B.is = function(a) { return B3(C.arr_or_p_to_array, B.find_i(function(v) { return a !== v; }), function(v) { return v === -1; }); };
+    B.isnt = function(a) { return B3(C.arr_or_p_to_array, B.find_i([I, B.is(a)]), B.is(-1)); };
 
     function base_loop_fn_base_args(list, keys, i) {
         var key = keys ? keys[i] : i;
@@ -352,41 +353,29 @@
     C.all = F("TODO");
     C.div = F("TODO");
     C.find_index = C.find_i = B.find_index(null);
+    C.to_array = _.toArray;
 
-    /* D start */
-    function D() {}
-    function BD() {}
-    // G['=== 0']= G['===0'] = D.is_zero = function(v) { return v === 0; };
-    // G['=== -1']= G['===-1'] = function(v) { return v === -1; };
+    C.add = B3(C.arr_or_p_to_array = IF(_.isArray, I).ELSE([P, C.to_array]), B.reduce(function(a, b) { return a + b; }));
+    C.sub = B3(C.arr_or_p_to_array, B.reduce(function(a, b) { return a - b; }));
+    C.mod = B3(C.arr_or_p_to_array, B.reduce(function(a, b) { return a % b; }));
+    C.mul = B3(C.arr_or_p_to_array, B.reduce(function(a, b) { return a * b; }));
+    C.div = B3(C.arr_or_p_to_array, B.reduce(function(a, b) { return a / b; }));
 
-    D.t = D.true = J(true);
-    D.f = D.false = J(false);
-    D.to_array = _.toArray;
-    
-    D.add = B([D.arr_or_p_to_array = IF(_.isArray, I).ELSE([P, D.to_array]), B.reduce(function(a, b) { return a + b; })]);
-    D.sub = B([D.arr_or_p_to_array, B.reduce(function(a, b) { return a - b; })]);
-    D.mod = B([D.arr_or_p_to_array, B.reduce(function(a, b) { return a % b; })]);
-    D.mul = B([D.arr_or_p_to_array, B.reduce(function(a, b) { return a * b; })]);
-    D.div = B([D.arr_or_p_to_array, B.reduce(function(a, b) { return a / b; })]);
+    C.parse_int = function(v) { return parseInt(v, 10); };
+    C.parse_int_all = B3(C.arr_or_p_to_array, B.map(C.parse_int));
+    C.iadd = B3(C.parse_int_all, C.add);
+    C.isub = B3(C.parse_int_all, C.sub);
 
-    D.parse_int = B([D.arr_or_p_to_array, B.map(function(v) { return parseInt(v); })]);
-    D.iadd = B([D.parse_int, D.add]);
-    D.isub = B([D.parse_int, D.sub]);
+    C.not = function(v) { return !v; };
+    C.nnot = function(v) { return !!v; };
 
-    BD.is = function(a) { return B([D.arr_or_p_to_array, B.find_i(function(v) { return a !== v; }), function(v) { return v === -1; }]); };
-    BD.isnt = function(a) { return B([D.arr_or_p_to_array, B.find_i([I, BD.is(a)]), BD.is(-1)]); };
+    C.and = B3(C.arr_or_p_to_array, B.find_i(C.not), B.is(-1));
+    C.or = B3(C.arr_or_p_to_array, B.find(I), C.nnot);
 
-    D.not = function(v) { return !v; };
-    D.nnot = function(v) { return !!v; };
-
-    D.and = B([D.arr_or_p_to_array, B.find_i(D.not), BD.is(-1)]);
-    D.or = B([D.arr_or_p_to_array, B.find(I), D.nnot]);
-
-    D.eq = B([D.arr_or_p_to_array, B.find_i(function(v,i,a) { return a[0] != v; }), BD.is(-1)]);
-    D.seq = B([D.arr_or_p_to_array, B.find_i(function(v,i,a) { return a[0] !== v; }), BD.is(-1)]);
-
-    D.neq = B([D.eq, D.not]);
-    D.sneq = B([D.seq, D.not]);
+    C.eq = B3(C.arr_or_p_to_array, B.find_i(function(v,i,a) { return a[0] != v; }), B.is(-1));
+    C.seq = B3(C.arr_or_p_to_array, B.find_i(function(v,i,a) { return a[0] !== v; }), B.is(-1));
+    C.neq = B3(C.eq, C.not);
+    C.sneq = B3(C.seq, C.not);
 
 
     function F(nodes) {
@@ -548,7 +537,10 @@
     }
     F.IF = window.IF = IF;
 
-    function J(v) { return function() { return v; } }
+    function J(v) { return function() { return v; }; }
+
+    J.t = J.true = J(true);
+    J.f = J.false = J(false);
 
     function M(obj, method) {
         return obj[method].apply(obj, _.rest(arguments, 2));

--- a/example/js/abc.js
+++ b/example/js/abc.js
@@ -54,7 +54,7 @@
     function B3() { return B(C.to_array(arguments)); }
 
     function base_bp(next, idx) {
-        if (arguments.length == 2) return function () { return arguments[idx] };
+        if (arguments.length == 2) return function () { return arguments[idx]; };
         var idxs = _.rest(arguments);
         return function() {
             return next(C.map(idxs, arguments, function(v, i, l, args) { return args[v]; }));
@@ -101,8 +101,8 @@
         };
     };
 
-    var c_if = IF(function() { return arguments.length == 3 }, R).ELSE(B.all(_.rest, B.V('0'), P1));
-    var b_if = IF(function() { return arguments.length > 1 }, R).ELSE(B.all(_.rest, B.V('0')));
+    var c_if = IF(function() { return arguments.length == 3; }, R).ELSE(B.all(_.rest, B.V('0'), P1));
+    var b_if = IF(function() { return arguments.length > 1; }, R).ELSE(B.all(_.rest, B.V('0')));
     B.reduce = function(iter) {
         return B([iter == null ? c_if : b_if,
                 B(function(result, list, keys, i, res, tmp, args) {     // body
@@ -186,7 +186,7 @@
             iter, // iter_or_predi
             base_loop_fn_base_args,
             base_loop_fn
-        )
+        );
     };
 
     B.some = function(iter) {
@@ -203,7 +203,7 @@
     B.every = function(iter) {
         return B(
             function(result, list, keys, i, res) { return i == 0 ? true : res; },   // body
-            function(v) { return !v }, // end_q
+            function(v) { return !v; }, // end_q
             J(false), // end
             J(true), // complete
             iter,
@@ -212,7 +212,7 @@
     };
 
     B.uniq = function(iter) {
-        iter = _.isString(iter) ? (function(key) { return function(val) { return val[key]; } })(iter) : (iter || I);
+        iter = _.isString(iter) ? (function(key) { return function(val) { return val[key]; }; })(iter) : (iter || I);
         return B(
             function(result, list, keys, i, res, tmp) { // body
                 if (i == 0) return;
@@ -265,7 +265,7 @@
 
             var res2 = A(params(list, keys, i++, res).concat(args), iter_or_predi, context);
             if (!maybe_promise(res2)) return f(res2);
-            res2.then(function(res) { f(res) });
+            res2.then(function(res) { f(res); });
             return resolve || C(CB(function(cb) { resolve = cb; }));
         })();
     }
@@ -389,7 +389,7 @@
     var TAB_SIZE = 4;
     var TAB = "( {"+TAB_SIZE+"}|\\t)"; // "( {4}|\\t)"
     var TABS = TAB + "+";
-    var number_of_tab = function(a) { return a.match(new RegExp("^"+TAB+"+"))[0].length/TAB_SIZE };
+    var number_of_tab = function(a) { return a.match(new RegExp("^"+TAB+"+"))[0].length/TAB_SIZE; };
 
     function H(var_names/*, source...*/) {
         return s.apply(null, [H, 'H', convert_to_html].concat(_.toArray(arguments)));


### PR DESCRIPTION
## D series 기본 기능 구현 (수정)

[이전 버전](#4)을 수정한 버전입니다.
- `BD.is` / `BD.isnt`: 빈 배열을 주는 경우 잘못된 값을 반환하는 문제 해결
- `BD` 전역 처리
- `D.notnot` => `D.nnot`
- 기타 `_.findIndex` 관련 처리
- 주석 제거
## D series, C.series로 병합
- 변경: D => C / BD => B / B([ ... ]) => B3( ... ) / D.t => J.t
- 삭제: D, BD
- 추가: B3
